### PR TITLE
Fix some bugs and fix batch upload for discovery

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:8.9.4-alpine
+
+COPY app.js /app/
+COPY package.json /app/
+COPY lib /app/lib
+COPY public /app/public
+
+WORKDIR /app
+RUN npm install
+
+CMD ["node", "app.js"]

--- a/couchdb.yaml
+++ b/couchdb.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: couchdb
+  labels:
+    app: couchdb
+spec:
+  ports:
+    - port: 5984
+      protocol: TCP
+      targetPort: 5984
+  type: LoadBalancer
+  selector:
+    app: couchdb
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: couchdb-deployment
+  labels:
+    app: couchdb
+spec:
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: couchdb
+    spec:
+      containers:
+        - image: couchdb:latest
+          name: couchdb
+          env:
+            - name: COUCHDB_USER
+              value: 'admin'
+            - name: COUCHDB_PASSWORD
+              value: 'password'
+          ports:
+            - containerPort: 5984
+          volumeMounts:
+            - name: couchdb-storage
+              mountPath: /opt/couchdb/data
+      volumes:
+        - name: couchdb-storage
+          persistentVolumeClaim:
+            claimName: couchdb-claim

--- a/lib/watson.js
+++ b/lib/watson.js
@@ -1,6 +1,7 @@
 var request = require('request');
 var jsonfile = require('jsonfile');
 var fs = require('fs');
+var async = require('async')
 
 var DiscoveryV1 = require('watson-developer-cloud/discovery/v1');
 config = jsonfile.readFileSync(__dirname + '/../config.json' );
@@ -199,38 +200,48 @@ class Watson {
  */
 watsonAddDocument(reviews, credentials) {
   var promise = new Promise(function (resolve,reject) {
-    var docs = 0;
-    var errFlag = false;
-    var recurse = false;
-    // console.log('reviews len: ')
-    // console.log(reviews.reviews.length)
-    var length = reviews.reviews.length;
-    for (var i = 0; i < length; i++) {
-      discovery.addJsonDocument({
-        environment_id: credentials.envID,
-        collection_id: credentials.collectionID,
-        file: reviews.reviews[i]
-      }, function(error, data) {
-        if (error && error.code === '429') {
-          console.log(error)
-          setTimeout(function(){
-            console.log('about to recursively call watson.watsonAddDoc') 
-            recurse = true;
-            watson.watsonAddDocument(reviews, credentials);}, 8000);                      
-        }
-        docs++;
-        if (recurse) {
-          console.log('recurse === true')
-          console.log('about tor esove data')
-          setTimeout(function(){ resolve(data);}, 8000);            
-          
-        }
-        if(docs === length) {
-          console.log('uploaded all of the docs. waiting for Watson Discovery to process documents...');
-          setTimeout(function(){ resolve(data);}, 8000);            
-        }
-      });
-    }
+    var length = reviews.reviews.length
+    var chunk = 10;
+    var arrayOfReviews = reviews.reviews;
+    var temporaryArray;
+    var i = 0;
+    console.log('reviews len: ');
+    console.log(length);
+
+    async.whilst(function () {
+      return i <= length;
+    },
+    function (next) {
+        var end = i+chunk-1;
+        console.log('uploading review ' + i + ' to ' + end);
+        temporaryArray = arrayOfReviews.slice(i,i+chunk);
+        console.log('MY TEMPORARY ARRAY LENGTH IS ' + temporaryArray.length)
+        var index = 0;
+        var uploadedReviews = 0;
+        while(index<temporaryArray.length) {
+          discovery.addJsonDocument({
+            environment_id: credentials.envID,
+            collection_id: credentials.collectionID,
+            file: temporaryArray[index]
+          }, function(error, data) {
+              if (error) {
+                console.log(error);
+              }
+              uploadedReviews++;
+              if (uploadedReviews == temporaryArray.length) {
+                i += chunk;
+                uploadedReviews = 0;
+                setTimeout(next, 500)
+              }
+          });
+          index++;
+      }
+    },
+    function (err) {
+      // All things are done!
+      console.log('done uploading')
+      resolve(true);
+    });
   });
   return promise;
 }
@@ -274,8 +285,8 @@ watsonAddDocument(reviews, credentials) {
         if (err) {
           reject('there is an error in the query');
         }
-        console.log('body: ');
-        console.log(body)
+        // console.log('body: ');
+        // console.log(body)
         resolve(body);
       });
     });

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "url": "https://github.com/IBM/watson-review-analyzer"
   },
   "dependencies": {
+    "async": "^2.6.0",
     "async-waterfall": "^0.1.5",
     "body-parser": "^1.17.x",
     "cheerio": "~1.0.0-rc.2",

--- a/public/analyze.js
+++ b/public/analyze.js
@@ -15,7 +15,7 @@ class Watson{
     data.source = document.getElementById("productUrl").value; 
     // console.log('data.source: ');
     // console.log(data.source);
-    var nodeUrl = 'http://localhost:4000/reviews/' + data.source;
+    var nodeUrl = 'reviews/' + data.source;
     var json = JSON.stringify(data);
     var ourRequest = new XMLHttpRequest();
     ourRequest.open("GET", nodeUrl, true);
@@ -85,7 +85,18 @@ class Watson{
 
           reviewsCont.innerHTML += 
           '<div class="stars-outer">' +
-          '<p id = "rating">' + 'Rating: ' + '</p>' +           '<div class="stars-inner"></div></div>';
+          '<p id = "rating">' + 'Rating: ' + '</p>';
+          var numberOfStars = 0;
+          var starsContent = "";
+          while (numberOfStars < output.results[i].rating) {
+            starsContent += "&#xf005 ";
+            numberOfStars++;
+          }
+          while (numberOfStars < 5) {
+            starsContent += "&#xf006 ";
+            numberOfStars++;
+          }
+          reviewsCont.innerHTML += '<div class="stars-inner fa">' + starsContent + '</div></div>';
           
 
           reviewsCont.innerHTML += '<p id = "reviewText">' + '<p><b>' +

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -141,17 +141,15 @@ label {
   display: inline-block;
   white-space: nowrap;
   overflow: hidden;
+  color: #f8ce0b;
+  text-shadow: -0.01px 0 orange, 0 0.01px orange, 0.01px 0 orange, 0 -0.01px orange;
 }
+
 #rating {
   display: inline-block;
   margin-right: .5em;
   margin-bottom: 2em; 
   margin-top: -1em;   
-}
- 
-.stars-inner::before {
-  content: "\f005 \f005 \f005 \f005 \f005";
-  color: #f8ce0b;
 }
 
 #reviewText {

--- a/volumes.yaml
+++ b/volumes.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: dev-volume
+  labels:
+    type: local
+spec:
+  capacity:
+    storage: 4Gi
+  accessModes:
+    - ReadWriteMany
+  hostPath:
+    path: /tmp/data/couchdb # This would only persist in a single-node. Use dynamic provisioning for multi-node clusters (paid). No need to create a Persistent Volume if you will use dynamic provisioning.
+  persistentVolumeReclaimPolicy: Recycle
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  annotations:
+    volume.beta.kubernetes.io/storage-class: "" # Comment this line to use dynamic provisioning (paid)
+  name: couchdb-claim
+  labels:
+    app: watson-reviews
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 4Gi

--- a/watson-review-analyzer.yaml
+++ b/watson-review-analyzer.yaml
@@ -1,0 +1,48 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: watson-reviews
+  labels:
+    app: watson-reviews
+spec:
+  ports:
+    - port: 80
+      protocol: TCP
+      targetPort: 4000
+  type: LoadBalancer
+  selector:
+    app: watson-reviews
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: watson-reviews-deployment
+  labels:
+    app: watson-reviews
+spec:
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: watson-reviews
+    spec:
+      containers:
+        - image: anthonyamanse/watson-reviews:v1
+          imagePullPolicy: Always
+          name: watson-reviews
+          env:
+            - name: CLOUDANT_URL
+              value: 'http://admin:password@couchdb:5984'
+          volumeMounts:
+            - name: config-file
+              mountPath: "/app/config.json"
+              subPath: "config.json"
+              readOnly: true
+          ports:
+            - containerPort: 4000
+      volumes:
+        - name: config-file
+          configMap:
+            name: watson-discovery-config


### PR DESCRIPTION
This commit fixes the following bugs:
- No res.send in performing a new scrape which results to unresolved request
- Fix batch upload of documents to Discovery. Previous method is uploading everything in parallel
- Add star ratings in front-end
- Moved watson.getDiscoveryEnvironments to main thread. Previous location of method is at the request which makes the first request fail as the config file environments is loaded asynchronously
- Add database products if it doesn't exists. Previous code needed a manual step to create one.

This commit also adds a Dockerfile and Kubernetes deployment files.
Kubernetes deployment allows the use of a couchdb.

Signed-off-by: AnthonyAmanse <ghieamanse@gmail.com>